### PR TITLE
Changed invalid tag attribute to tagName

### DIFF
--- a/behave-ui-hotkeys.js
+++ b/behave-ui-hotkeys.js
@@ -54,7 +54,7 @@
             }
 
             // make non-focusable elements focusable
-            if (!/(input|textarea)/.test(this.view.el.tag.toLowerCase())) {
+            if (!/(input|textarea)/.test(this.view.el.tagName.toLowerCase())) {
                 this.view.$el
                     .attr('tabindex', 0)
                     .css('outline', '0px solid transparent');


### PR DESCRIPTION
@kkemple One more pull request here.

view.el.tag doesn't appear to be a valid attribute.  It throws an error for me in Chrome and presumably doesn't work (I'm not actually using this scoped to an input right now).  

I'm pretty sure [element.tagName](https://developer.mozilla.org/en-US/docs/Web/API/Element.tagName) was what you wanted there, unless you're shimming something that I don't have.