### PR TITLE
Use 10 as keycode for return as well as enter

### DIFF
--- a/behave-ui-hotkeys.js
+++ b/behave-ui-hotkeys.js
@@ -133,7 +133,7 @@
         "backspace" : 8,
         "tab"       : 9,
         "enter"     : 10,
-        "return"    : 13,
+        "return"    : 10,
         "pause"     : 19,
         "esc"       : 27,
         "space"     : 32,


### PR DESCRIPTION
In actual practice this seems to be a better representation of how browsers implement keycodes for return.

Would close #6