### PR TITLE
Fix enter key

### DIFF
--- a/behave-ui-hotkeys.js
+++ b/behave-ui-hotkeys.js
@@ -132,8 +132,8 @@
     keyMap = {
         "backspace" : 8,
         "tab"       : 9,
-        "enter"     : 10,
-        "return"    : 10,
+        "enter"     : 13,
+        "return"    : 13,
         "pause"     : 19,
         "esc"       : 27,
         "space"     : 32,


### PR DESCRIPTION
Use keycode `13` instead of `10` for `enter`.

I couldn't find proof of any modern browser not supporting `13`. Instead, currently I have no luck with the enter key on FF/Chrome. Is there something I don't know? :)