### PR TITLE
Fix event handler removal

### DIFF
--- a/behave-ui-hotkeys.js
+++ b/behave-ui-hotkeys.js
@@ -50,7 +50,8 @@
         },
         onRender: function() {
             if (this.options.attachToDocument) {
-                $(document).on('keydown', this._processHotkeys.bind(this));
+                this._processHotkeys = this._processHotkeys.bind(this);
+                Backbone.$(document).on('keydown', this._processHotkeys);
             }
 
             // make non-focusable elements focusable
@@ -123,7 +124,7 @@
         },
         onBeforeDestroy: function() {
             if (this.options.attachToDocument) {
-                $(document).off('keydown', this._processHotkeys.bind(this));
+                Backbone.$(document).off('keydown', this._processHotkeys);
             }
         }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "behave-ui-hotkeys",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "A hotkeys marionette behavior",
   "main": "src/behave-ui-hotkeys.js",
   "scripts": {


### PR DESCRIPTION
When `attachToDocument` is `true`, the `keydown` handler is now
correctly removed from `document`.