### PR TITLE
Add value() to the end of each function chain to appease lodash

### DIFF
--- a/behave-ui-hotkeys.js
+++ b/behave-ui-hotkeys.js
@@ -46,7 +46,7 @@
             }
 
             this.hotkeys = [];
-            _(this.options.hotkeys).each(this._buildHotkeyCache.bind(this));
+            _(this.options.hotkeys).each(this._buildHotkeyCache.bind(this)).value();
         },
         onRender: function() {
             if (this.options.attachToDocument) {
@@ -81,7 +81,7 @@
                 .each(function(hk) {
                     this.view.trigger('hotkey:' + hk.hotkey);
                     if (this.view[hk.method]) this.view[hk.method](e);
-                }.bind(this));
+                }.bind(this)).value();
         },
         _buildHotkeyCache: function(method, hotkey) {
             var cmd = false,
@@ -110,7 +110,7 @@
                         code = lookup(k);
                         break;
                 }
-            });
+            }).value();
 
             this.hotkeys.push({
                 hotkey: hotkey,


### PR DESCRIPTION
Lodash chaining is "lazy" so it won't execute anything in a chain until the chain has been completed.  You need to add a `value()` call to the end of the chain to mark it completed (even though thats nonsensical when using chaining for side effects as this library does).  This pull request adds the required value calls to get this working when used with lodash (otherwise it fails to parse the hashes).   